### PR TITLE
Add support for custom user sequences

### DIFF
--- a/jquery.velocity.js
+++ b/jquery.velocity.js
@@ -228,6 +228,8 @@ The biggest cause of both codebase bloat and codepath obfuscation in Velocity is
         },
         /* Velocity's full re-implementation of jQuery's CSS stack. Made global for unit testing. */
         CSS: { /* Defined below. */ },
+        /* An enumeration of custom animation sequences that users can add to velocity */
+        Sequence: {},
         /* Utility function's alias of $.fn.velocity(). Used for raw DOM element animation. */
         animate: function () { /* Defined below. */ },
         /* Set to 1 or 2 (most verbose) to log debug info to console. */
@@ -1109,6 +1111,9 @@ The biggest cause of both codebase bloat and codepath obfuscation in Velocity is
                 /* Treat a plain, non-empty object as a literal properties map. */
                 if ($.isPlainObject(propertiesMap) && !$.isEmptyObject(propertiesMap)) {
                     action = "start";
+                /* Check if the specified action maps to a user-defined sequence  */
+                } else if (typeof propertiesMap === "string" && $.velocity.Sequence[propertiesMap]) {
+                    return $.velocity.Sequence[propertiesMap].call(elements, options);
                 /* Treat a string as a CSS class reference. (See CSS Class Extraction above.) */
                 } else if (typeof propertiesMap === "string" && $.velocity.Classes.extracted[propertiesMap]) {
                     /* Assign the map to that of the extracted CSS class being referenced. */


### PR DESCRIPTION
PR for changes as that were brought up in Issue #20 (https://github.com/julianshapiro/velocity/issues/20).

In summation, this change set adds support for user-defined animation sequences. This has proved to be a huge win, as I am porting all of our `animation` calls to `velocity`. We reuse a lot of specific animations and having short-hand access to them is, to put it lightly, life changing. An example of a custom defined sequence would be:

```
$.velocity.Sequencee.fadeOut = function(options) {
    var opts = { display: "none" };

    var propertiesMap = {
        opacity: 0
    };

    jQuery(this).velocity(propertiesMap, $.extend(options, opts));
};
```

Now I can just do `$('div').velocity('fadeIn')`. Awesome. What's even better is we can all imagine a world in which sequences do crazy awesome things beyond just fading in elements.
