### PR TITLE
Add option to set a custom display value on complete.

### DIFF
--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -500,7 +500,9 @@
                         opts.delay = options.delay;
                         opts.begin = options.begin;
 
-                        if (/In$/.test(effectName)) {
+                        if (options.display) {
+                            opts.display = options.display;
+                        } else if (/In$/.test(effectName)) {
                             opts.display = Container.Velocity.CSS.Values.getDisplayType(element);
                         }
                     }


### PR DESCRIPTION
in Velocity UI, sometimes we don't want to automatically switch to the default CSS display value when transitioning in, so I've made a small edit in velocity.ui.js which now lets you supply an option 'display' to override the default value.

A use case would be, for instance, vertically centered text:

``` css
div.center-vertically {
    display: none; /* must be 'flex' for vertical centering, 'block' will not center */
    flex-direction: column;
    justify-content: center;
}
```

Transitioning in while preserving vertical centricity:

``` javascript
    $('.center-vertically').velocity('transition.expandIn', {display: 'flex'});
```
