### PR TITLE
velocity.ui: Prevent display none at out-animations with new option

### DIFF
--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -515,12 +515,16 @@
                                     options.complete && options.complete.call();
 									options.begin && options.begin.call();
                                 }
-                                
+
                                 if(options.opacity)	effect.reset.opacity = [0, 0];
                                 Container.Velocity.animate(element, effect.reset, { duration: 0, queue: false });
                             };
                         } else {
-                            opts.complete = options.complete;
+							/* Since sequences are triggered individually for each element in the animated set, we avoid repeatedly triggering callbacks by firing them only when the final element is reached. */
+							if (elementsIndex !== elementsSize - 1) {
+								opts.complete = options.complete;
+								opts.begin = options.begin;
+							}
                         }
                         
                         if (/Out$/.test(effectName) && !options.opacity) {


### PR DESCRIPTION
Hey,

in one of my projects i used velocity(.ui) to animate some texts and images IN/OUT based on the scroll position.
This works great, if i set the element to <code>opacity:0;</code> and animate it IN with <code>$elem.velocity("transition.slideUpIn")</code>.
But when i animate the element out the other content jump up. Not very nice.

To fix that problem i added the option <code>opacity: true/false;</code>. On true the out-animation will not reset the css of the element to <code>opacity:1; display:none;</code>

Example of the problem and the new option:
http://codepen.io/anon/pen/JyroK
