### PR TITLE
UI Pack: Option to skip property resetting

### DIFF
--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -515,15 +515,7 @@
                     }
 
                     if (callIndex === effect.calls.length - 1) {
-                        if (effect.reset && !options.skipReset) {
-                            opts.complete = function() {
-                                if (finalElement) {
-                                    options.complete && options.complete.call();
-                                }
-
-                                Container.Velocity.animate(element, effect.reset, { duration: 0, queue: false });
-                            };
-                        } else if (finalElement) {
+                        if (finalElement) {
                             opts.complete = options.complete;
                         }
 
@@ -533,6 +525,10 @@
                             } else if (/Out$/.test(effectName)) {
                                 opts.display = "none";
                             }
+                        }
+
+                        if (effect.reset) {
+                            Container.Velocity.animate(element, effect.reset, { duration: 0, queue: false });
                         }
                     }
 


### PR DESCRIPTION
I'm wrapping Velocity / Velocity UI into an AngularJS module at the moment, and to do so I'm running 'In' transitions, and then automatically prepping the element to run the corresponding "Out" animation when appropriate.

The issue comes when Velocity UI goes to run the completed callbacks after all effect calls have been run. In situations as described above, it actually needs to skip over the code block that runs between lines 518 and 526 if (effect.reset) evaluates to true.

Would it be possible to add an option (skipReset?) to optionally bypass that code block?

I can create a PR, I just need to know if you'd like the default value of false defined in Velocity's defaults. This would be a UI-Pack-only option so I'm not sure if it's appropriate to define it's default value in the parent library or not.

Thoughts?
