### PR TITLE
Implemented Promises support

### DIFF
--- a/jquery.velocity.js
+++ b/jquery.velocity.js
@@ -1620,8 +1620,8 @@ Velocity's structure:
 
                 /* Since we're stopping, do not proceed with Queueing. */
                 if (promise) {
-                    /* Reject promise with chained context to indicate: "no error, simply stopping". */
-                    rejecter(getChain());
+                    /* Just resolve the promise with chained context. */
+                    resolver(getChain());
                     return promise;
                 }
                 return getChain();


### PR DESCRIPTION
Notice on _stop_ I reject the promise with the chained context. I know it's contrary to what Dominic said but it seemed to be the best solution, and I couldn't find anything in the specs about the `reason` having to be an error.

Also, I went over the code and think I covered all places where you return from the `animate` method, so please check if I missed anything.
