### PR TITLE
Do not reset scale to 1 if value is forcefed

### DIFF
--- a/jquery.velocity.js
+++ b/jquery.velocity.js
@@ -872,9 +872,9 @@ Velocity's structure:
                                         case "scal":
                                         case "scale":
                                             /* Chrome on Android has a bug in which scaled elements blur if their initial scale
-                                               value is below 1 (which can happen with forcefeeding). Thus, we detect a yet-unset scale property
+                                               value is below 1. Thus, we detect a yet-unset scale property
                                                and ensure that its first value is always 1. More info: http://stackoverflow.com/questions/10417890/css3-animations-with-transform-causes-blurred-elements-on-webkit/10417962#10417962 */
-                                            if (Velocity.State.isAndroid && Data(element).transformCache[transformName] === undefined) {
+                                            if (propertyValue === undefined && Velocity.State.isAndroid && Data(element).transformCache[transformName] === undefined) {
                                                 propertyValue = 1;
                                             }
 


### PR DESCRIPTION
Velocity [resets scale](https://github.com/julianshapiro/velocity/blob/master/jquery.velocity.js#L874-L879) on android to 1 regardless of a forcefed value.

I forcefeed the value that I intend the animation to start from, but instead there is a flash of the element jumping to scale 1. If there is a forcefed value, velocity should accept it instead of overriding it.

An alternate proposal is that I can add a default option flag `_initializeAndroidScale` that can be set to false?
