### PR TITLE
Fixes Component dependencies

### DIFF
--- a/component.json
+++ b/component.json
@@ -20,6 +20,6 @@
     "jquery.velocity.js"
   ],
   "dependencies": {
-    "jquery/jquery": "*"
+    "components/jquery": "*"
   }
 }


### PR DESCRIPTION
Per https://github.com/julianshapiro/blast/pull/4, right now if you try to install Velocity with Component you get the following error:

``` sh
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: can't find remote for "jquery/jquery"
    at /usr/local/lib/node_modules/component/node_modules/component-package/index.js:387:28
    at CB (/usr/local/lib/node_modules/component/node_modules/component-package/node_modules/rimraf/rimraf.js:46:5)
    at /usr/local/lib/node_modules/component/node_modules/component-package/node_modules/rimraf/rimraf.js:64:14
    at Object.oncomplete (fs.js:107:15)
```

This will fix that, and [get jQuery from here](https://github.com/components/jquery) instead.
