### PR TITLE
require fix

### DIFF
--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -6,7 +6,7 @@
 
 ;(function (factory) {
     /* CommonJS module. */
-    if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+    if (typeof require === "function" && typeof exports === "object" ) {
         module.exports = factory();
     /* AMD module. */
     } else if (typeof define === "function" && define.amd) {


### PR DESCRIPTION
Dear Julian,

The velocity-animte as commonjs package cannot be used at this moment in webpack environment.

The reason is the velicoty.ui.js file's define line

```
define([ "velocity" ], factory);
```

The npm package is called velocity-animate, so that line works only if the define looks like this:

```
define([ "velocity-animate" ], factory);
```

The name "velocity" is already taken in npmjs by some template stuff...
