### PR TITLE
Set the non-"none" display value for tables in certain redirects, like fadeIn/Out

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -1577,6 +1577,8 @@ return function (global, window, document, undefined) {
                     return "list-item";
                 } else if (/^(tr)$/i.test(tagName)) {
                     return "table-row";
+                } else if (/^(table)$/i.test(tagName)) {
+                    return "table";
                 /* Default to "block" when no match is found. */
                 } else {
                     return "block";


### PR DESCRIPTION
It seems like getDisplayType() was defaulting HTML tables to be assigned "display:block;" after a fadeIn. I found that we were getting some weird display issues because of this. I think it makes sense to default to "display:table;" instead.

Is there any reason not to?