### PR TITLE
Allow any version of jquery, don't need to specify github repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "*.md"
   ],
   "dependencies": {
-    "jquery": "jquery/jquery"
+    "jquery": "*"
   },
   "repository" :
   { 


### PR DESCRIPTION
The `bower.json` file currently uses `jquery/jquery` in the version specifier for the jquery dependency. This isn't necessary (and is confusing), since the package name in bower is simply `jquery`. This PR changes to using a standard wildcard version specifier.

Alternatively, we may wish to remove this dependency altogether, since velocity no longer has a hard dependency on jquery.