### PR TITLE
Deleted Velocity from global in commonjs implementation.

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -410,6 +410,7 @@
     /* CommonJS module. */
     if (typeof module === "object" && typeof module.exports === "object") {
         module.exports = factory();
+        delete window.Velocity;
     /* AMD module. */
     } else if (typeof define === "function" && define.amd) {
         define(factory);

--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -22,12 +22,17 @@ return function (global, window, document, undefined) {
         Checks
     *************/
 
-    if (!global.Velocity || !global.Velocity.Utilities) {
-        window.console && console.log("Velocity UI Pack: Velocity must be loaded first. Aborting.");
-        return;
+    /* CommonJS module. */
+    if (typeof require === "function" && typeof exports === "object" ) {
+      var Velocity = require('velocity-animate'),
+          $ = Velocity.Utilities;
+      /* Browser globals. */
+    } else if (!global.Velocity || !global.Velocity.Utilities) {
+      window.console && console.log("Velocity UI Pack: Velocity must be loaded first. Aborting.");
+      return;
     } else {
-        var Velocity = global.Velocity,
-            $ = Velocity.Utilities;
+      var Velocity = global.Velocity,
+          $ = Velocity.Utilities;
     }
 
     var velocityVersion = Velocity.version,


### PR DESCRIPTION
This removes the global instance of velocity for commonjs (browserify).  

Example usage:

```
var velocity = require('velocity-animate');
require('velocity-animate/velocity.ui');

velocity.animate($('#foobar'), 'transition.slideRightIn', 400);
``` 