### PR TITLE
Remove jQuery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,9 +27,6 @@
     "LICENSE",
     "*.md"
   ],
-  "dependencies": {
-    "jquery": "*"
-  },
   "repository" :
   { 
     "type" : "git",


### PR DESCRIPTION
It's jQuery-compatible, but jQuery is not required. Right?

Also, for some reason I'm having a hard time overriding the component not to require jQuery, but that's probably just a [wiredep](https://github.com/taptapship/wiredep) bug.