### PR TITLE
`transformOrder` added

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -623,6 +623,7 @@ return function (global, window, document, undefined) {
             loop: false,
             delay: false,
             mobileHA: true,
+            transformOrder: [],
             /* Advanced: Set to false to prevent property values from being cached between consecutive Velocity-initiated chain calls. */
             _cacheValues: true
         },
@@ -1923,12 +1924,35 @@ return function (global, window, document, undefined) {
                     }
                 });
             } else {
-                var transformValue,
+                var transformCache = Data(element).transformCache,
+                    transformOrder = Data(element).opts.transformOrder,
+                    orderedTransformCache,
+                    transformName,
+                    transformValue,
                     perspective;
 
                 /* Transform properties are stored as members of the transformCache object. Concatenate all the members into a string. */
-                $.each(Data(element).transformCache, function(transformName) {
-                    transformValue = Data(element).transformCache[transformName];
+
+                orderedTransformCache = $.map(transformCache, function(value, index) {
+                    return {name: index, value: value};
+                });
+
+                orderedTransformCache.sort(function(a, b) {
+                    var indexA = transformOrder.indexOf(a.name),
+                        indexB = transformOrder.indexOf(b.name);
+
+                    if (indexA > indexB) {
+                        return 1;
+                    } else if (indexA < indexB) {
+                        return - 1;
+                    }
+
+                    return 0;
+                });
+
+                $.each(orderedTransformCache, function(transformIndex, transformOb) {
+                    transformValue = transformOb.value;
+                    transformName = transformOb.name;
 
                     /* Transform's perspective subproperty must be set first in order to take effect. Store it temporarily. */
                     if (transformName === "transformPerspective") {


### PR DESCRIPTION
Solution for #197. There is now an options argument called `transformOrder` which is by default an empty array. It can be filled with an ordered list of transform properties as strings. It will sort the `transformCache` before applying it.