### PR TITLE
Allow animation of outerWidth & outerHeight

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -1457,6 +1457,42 @@ return function (global, window, document, undefined) {
                         };
                     })();
                 }
+
+                /**************
+                  Dimensions
+                 **************/
+                function augmentDimension(name, element) {
+                    var sides = name === 'width' ? ['Left', 'Right' ] : ['Top', 'Bottom'];
+
+                    if (CSS.getPropertyValue(element, "boxSizing").toString().toLowerCase() === 'border-box') {
+                        /* in box-sizing mode, the CSS width / height accessors already give the outerWidth / outerHeight. */
+                        return 0;
+                    } else {
+                        var augment = 0;
+                        var fields = ['padding'+sides[0], 'padding'+sides[1], 'border'+sides[0]+'Width', 'border'+sides[1]+'Width'];
+                        for (var i = 0; i < fields.length; i++) {
+                            var value = parseFloat(CSS.getPropertyValue(element, fields[i]));
+                            if (!isNaN(value)) {
+                                augment += value;
+                            }
+                        }
+                        return augment;
+                    }
+                }
+                function outerDimension(name) {
+                    return function(type, element, propertyValue) {
+                        switch (type) {
+                        case "name":
+                            return name;
+                        case "extract":
+                            return parseFloat(propertyValue) + augmentDimension(name, element);
+                        case "inject":
+                            return (parseFloat(propertyValue) - augmentDimension(name, element)) + "px";
+                        }
+                    };
+                }
+                CSS.Normalizations.registered.outerWidth = outerDimension('width');
+                CSS.Normalizations.registered.outerHeight = outerDimension('height');
             }
         },
 


### PR DESCRIPTION
This makes it possible to animate `outerWidth` & `outerHeight`, which are intended to be defined exactly the same as jQuery's. This makes it easier to robustly animate one element to overlap another, despite variations of box-sizing, border, and padding.