### PR TITLE
ADD commonJS support with proper local scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,5 @@
     "velocity.min.js",
     "velocity.ui.js",
     "velocity.ui.min.js"
-  ],
-  "dependencies": {
-    "jquery": ">= 1.4.3"
-  },
-  "devDependencies": {
-    "grunt": "^0.4.4",
-    "grunt-contrib-concat": "~0.4.0",
-    "grunt-contrib-jshint": "~0.6.3",
-    "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt-contrib-requirejs": "~0.4.4",
-    "grunt-contrib-uglify": "~0.2.2"
-  }
+  ]
 }

--- a/velocity.js
+++ b/velocity.js
@@ -1,5 +1,9 @@
 /*! VelocityJS.org (1.2.2). (C) 2014 Julian Shapiro. MIT @license: en.wikipedia.org/wiki/MIT_License */
-
+var isCommonJS  = (typeof module === "object" && typeof module.exports === "object"),
+    isJquery    = window.jQuery,
+    isLocal     = (isCommonJS && !isJquery),
+    UTIL        = {},
+    GLOBAL      = isLocal ? UTIL : window;
 /*************************
    Velocity jQuery Shim
 *************************/
@@ -400,7 +404,7 @@
 
     /* Globalize Velocity onto the window, and assign its Utilities property. */
     window.Velocity = { Utilities: $ };
-})(window);
+})(GLOBAL);
 
 /******************
     Velocity.js
@@ -552,6 +556,8 @@ return function (global, window, document, undefined) {
     if (global.fn && global.fn.jquery) {
         $ = global;
         isJQuery = true;
+    } else if (isLocal) {
+        $ = UTIL.Velocity.Utilities;
     } else {
         $ = window.Velocity.Utilities;
     }
@@ -2190,7 +2196,7 @@ return function (global, window, document, undefined) {
                             }
 
                             /* Iterate through the calls targeted by the stop command. */
-                            $.each(elements, function(l, element) {                                
+                            $.each(elements, function(l, element) {
                                 /* Check that this call was applied to the target element. */
                                 if (element === activeElement) {
                                     /* Optionally clear the remaining queued calls. */
@@ -3473,7 +3479,7 @@ return function (global, window, document, undefined) {
                             tween.currentValue = currentValue;
 
                             /* If we're tweening a fake 'tween' property in order to log transition values, update the one-per-call variable so that
-                               it can be passed into the progress callback. */ 
+                               it can be passed into the progress callback. */
                             if (property === "tween") {
                                 tweenDummyValue = currentValue;
                             } else {
@@ -3765,10 +3771,17 @@ return function (global, window, document, undefined) {
     global.Velocity = Velocity;
 
     if (global !== window) {
-        /* Assign the element function to Velocity's core animate() method. */
-        global.fn.velocity = animate;
-        /* Assign the object function's defaults to Velocity's global defaults object. */
-        global.fn.velocity.defaults = Velocity.defaults;
+        if (global.fn) {
+          /* Assign the element function to Velocity's core animate() method. */
+          global.fn.velocity = animate;
+          /* Assign the object function's defaults to Velocity's global defaults object. */
+          global.fn.velocity.defaults = Velocity.defaults;
+        } else if (global.Velocity.Utilities.fn) {
+          /* Assign the element function to Velocity's core animate() method. */
+          global.Velocity.Utilities.fn.velocity = animate;
+          /* Assign the object function's defaults to Velocity's global defaults object. */
+          global.Velocity.Utilities.fn.velocity.defaults = Velocity.defaults;
+        }
     }
 
     /***********************
@@ -3856,7 +3869,7 @@ return function (global, window, document, undefined) {
     });
 
     return Velocity;
-}((window.jQuery || window.Zepto || window), window, document);
+}((GLOBAL.jQuery || GLOBAL.Zepto || GLOBAL), window, document);
 }));
 
 /******************

--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -7,7 +7,7 @@
 ;(function (factory) {
     /* CommonJS module. */
     if (typeof require === "function" && typeof exports === "object" ) {
-        module.exports = factory();
+        module.exports = function (Velocity) { return factory(Velocity); };
     /* AMD module. */
     } else if (typeof define === "function" && define.amd) {
         define([ "velocity" ], factory);
@@ -15,14 +15,17 @@
     } else {
         factory();
     }
-}(function() {
+}(function(VELOCITY) {
 return function (global, window, document, undefined) {
 
     /*************
         Checks
     *************/
 
-    if (!global.Velocity || !global.Velocity.Utilities) {
+    if (VELOCITY) {
+      var Velocity = VELOCITY,
+          $ = VELOCITY.Utilities;
+    } else if (!global.Velocity || !global.Velocity.Utilities) {
         window.console && console.log("Velocity UI Pack: Velocity must be loaded first. Aborting.");
         return;
     } else {


### PR DESCRIPTION
I already saw [bobbyrenwick/velocity](https://github.com/bobbyrenwick/velocity) and the pull request [#479](https://github.com/julianshapiro/velocity/pull/479), but it did not work for me and the DIFF looked not very informative, so i implemented it myself.

The problem is, I didn't want to re-write so many things, so I kind of **"hacked"** it somehow.
In addition, there needs to be communication between **velocity** and **velocityUI**.

Normally **velocity** has to be loaded before **velocityUI**, so that the later can attach itself to the former by adding stuff to the global. So I chose to solve the usage like the following:

```js
var velocity = require('velocity-animate');
// activate velocity UI pack
require('velocity-animate/velocity.ui')(velocity);
```

*In addition, i removed __jQuery__ as a dependency from __package.json__, the same with all that __"grunt stuff"__, because neither were there scripts in the package.json nor is/was there a __Gruntfile.js__, so I wasn't really sure what it's good for. If it's needed, I can put it back in. My editor also fixed some white space issues, which I hope are an improvement, even though they now ended up in the same commit.*

