### PR TITLE
Fix animateParentHeight height calc when border-box

### DIFF
--- a/velocity.ui.js
+++ b/velocity.ui.js
@@ -80,7 +80,14 @@ return function (global, window, document, undefined) {
 
                 parentNode = element.parentNode;
 
-                $.each([ "height", "paddingTop", "paddingBottom", "marginTop", "marginBottom"], function(i, property) {
+                propertiesToSum = ["height", "paddingTop", "paddingBottom", "marginTop", "marginBottom"]
+
+                /* If box-sizing is border-box, the height already includes padding and margin */
+                if (Velocity.CSS.getPropertyValue(element, "boxSizing").toString().toLowerCase() === "border-box") {
+                    propertiesToSum = ["height"]
+                }
+
+                $.each(propertiesToSum, function(i, property) {
                     totalHeightDelta += parseFloat(Velocity.CSS.getPropertyValue(element, property));
                 });
             });


### PR DESCRIPTION
You usually don't merge pull requests, but this was reported some time ago,
and I needed a quick fix for myself, so why not upload it. Even though
animateParentHeight is probably going to be overhauled.

animateParentHeight was over-calculating the height of the children elements
which have the box-sizing set to box border. This resulted in the parent
being animated too tall: http://jsbin.com/xakipigino/1/edit

For elements with box-sizing: "border-box", the height value returned by
Velocity.CSS.getPropertyValue(element, 'height') already includes
padding and border. So in these cases, padding and border should no be
added when calculating the total height occupied the element:
http://jsbin.com/wiyejuxequ/1/edit
