### PR TITLE
Fix severe hangs in tick() when overflowing 10,000 call compaction limit

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -3360,6 +3360,7 @@ return function (global, window, document, undefined) {
                has been continuous with many elements over a long period of time; whenever all active calls are completed, completeCall() clears Velocity.State.calls. */
             if (callsLength > 10000) {
                 Velocity.State.calls = compactSparseArray(Velocity.State.calls);
+                callsLength = Velocity.State.calls.length;
             }
 
             /* Iterate through each active call. */


### PR DESCRIPTION
Tick wasn't properly resetting the `callsLength` variable after compacting the calls array. [Repro](https://jsfiddle.net/65xCP/126/), tested in Linux chrome. The basic behavior is call recalls itself on each complete until there are more than 10,000 calls in the queue, velocity tries to compact, and on every subsequent tick is forced to process and complete all 10,000 calls, none of which are false, before continuing. This obviously has a somewhat negative effect on FPS, dropping it to around 1 frame every 3 seconds.

Took a couple days of digging through the code, but what I think is going on is that the calls left after compaction are adding more calls, which are getting executed on the same tick due to the erroneous `callsLength` value, as velocity typically relies on that pre-cached value to prevent executing calls that were just added... though I'm not entirely sure, because all the calls are identical, which I don't know how to explain. What is certain is that, for whatever reason, this change fixes the issue.

I know you don't typically merge PRs, but I needed this fix anyways for my project, and figured if I'm opening an issue and writing a repro I may as well attach my fix.