### PR TITLE
Using $.offset to calculate position instead of $.position when scrolling in a container

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -2530,10 +2530,10 @@ return function (global, window, document, undefined) {
                                (due to the user's natural interaction with the page). */
                             scrollPositionCurrent = opts.container["scroll" + scrollDirection]; /* GET */
 
-                            /* $.position() values are relative to the container's currently viewable area (without taking into account the container's true dimensions
-                               -- say, for example, if the container was not overflowing). Thus, the scroll end value is the sum of the child element's position *and*
-                               the scroll container's current scroll position. */
-                            scrollPositionEnd = (scrollPositionCurrent + $(element).position()[scrollDirection.toLowerCase()]) + scrollOffset; /* GET */
+                            /* using offsets to calculate the element's position values relative to the container's currently viewable area (without taking into account the 
+                               container's true dimensions -- say, for example, if the container was not overflowing). Thus, the scroll end value is the sum of the 
+                               child element's position *and* the scroll container's current scroll position. */
+                            scrollPositionEnd = (scrollPositionCurrent + $(element).offset()[scrollDirection.toLowerCase()] - $(opts.container).offset()[scrollDirection.toLowerCase()]) + scrollOffset; /* GET */
                         /* If a value other than a jQuery object or a raw DOM element was passed in, default to null so that this option is ignored. */
                         } else {
                             opts.container = null;


### PR DESCRIPTION
Changed to use offsets of the container and the target element to calculate the position. $.position is only relative to the parent, so it won't work well when the element you want to scroll to is deeply nested. 
