### PR TITLE
Remove jQuery dependency from package.json and bower.json 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,9 +27,6 @@
     "LICENSE",
     "*.md"
   ],
-  "dependencies": {
-    "jquery": "*"
-  },
   "repository" :
   {
     "type" : "git",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "velocity.ui.js",
     "velocity.ui.min.js"
   ],
-  "dependencies": {
-    "jquery": ">= 1.4.3"
-  },
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-contrib-concat": "~0.4.0",


### PR DESCRIPTION
As per https://github.com/julianshapiro/velocity/issues/542

Testing this using my fork results in bower referencing your repo and still installing jQuery. About to change repo address and test, but obviously don't want that in the pull-request.