### PR TITLE
'use strict' compatible

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -1637,7 +1637,7 @@ return function (global, window, document, undefined) {
                         CSS.setPropertyValue(element, "display", CSS.Values.getDisplayType(element));
                     }
 
-                    function revertDisplay () {
+                    var revertDisplay = function revertDisplay () {
                         if (toggleDisplay) {
                             CSS.setPropertyValue(element, "display", "none");
                         }
@@ -1883,7 +1883,7 @@ return function (global, window, document, undefined) {
             if ((IE || (Velocity.State.isAndroid && !Velocity.State.isChrome)) && Data(element).isSVG) {
                 /* Since transform values are stored in their parentheses-wrapped form, we use a helper function to strip out their numeric values.
                    Further, SVG transform properties only take unitless (representing pixels) values, so it's okay that parseFloat() strips the unit suffixed to the float value. */
-                function getTransformFloat (transformProperty) {
+                var getTransformFloat = function getTransformFloat (transformProperty) {
                     return parseFloat(CSS.getPropertyValue(element, transformProperty));
                 }
 
@@ -2707,7 +2707,7 @@ return function (global, window, document, undefined) {
                        or 2) an array in the form of [ endValue, [, easing] [, startValue] ].
                        The optional third parameter is a forcefed startValue to be used instead of querying the DOM for
                        the element's current value. Read Velocity's docmentation to learn more about forcefeeding: VelocityJS.org/#forcefeeding */
-                    function parsePropertyValue (valueData, skipResolvingEasing) {
+                    var parsePropertyValue = function parsePropertyValue (valueData, skipResolvingEasing) {
                         var endValue = undefined,
                             easing = undefined,
                             startValue = undefined;
@@ -2878,7 +2878,7 @@ return function (global, window, document, undefined) {
                             operator = false;
 
                         /* Separates a property value into its numeric value and its unit type. */
-                        function separateValue (property, value) {
+                        var separateValue = function separateValue (property, value) {
                             var unitType,
                                 numericValue;
 
@@ -2960,7 +2960,7 @@ return function (global, window, document, undefined) {
                            of batching the SETs and GETs together upfront outweights the potential overhead
                            of layout thrashing caused by re-querying for uncalculated ratios for subsequently-processed properties. */
                         /* Todo: Shift this logic into the calls' first tick instance so that it's synced with RAF. */
-                        function calculateUnitRatios () {
+                        var calculateUnitRatios = function calculateUnitRatios () {
 
                             /************************
                                 Same Ratio Checks

--- a/velocity.js
+++ b/velocity.js
@@ -145,10 +145,11 @@
 
     /* Custom */
     $.data = function (node, key, value) {
+       var id, store;
         /* $.getData() */
         if (value === undefined) {
-            var id = node[$.expando],
-                store = id && cache[id];
+            id = node[$.expando];
+            store = id && cache[id];
 
             if (key === undefined) {
                 return store;
@@ -159,7 +160,7 @@
             }
         /* $.setData() */
         } else if (key !== undefined) {
-            var id = node[$.expando] || (node[$.expando] = ++$.uuid);
+            id = node[$.expando] || (node[$.expando] = ++$.uuid);
 
             cache[id] = cache[id] || {};
             cache[id][key] = value;


### PR DESCRIPTION
Firefox  is yelling at velocity when used in strict mode because of several errors.

Velocity is not (yet?) in strict mode, but some developers (like me) force it in their whole project, this PR make it sure velocity is ok in strict mode.

There is a lot more to do to clean this project, jshint and jscs are so throwing warnings and errors on it, but at least it will not crash under Firefox anymore.