### PR TITLE
Fixes #460 (callbacks for slideUp/Down - behaviour breaking change)

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -3811,7 +3811,7 @@ return function (global, window, document, undefined) {
             /* Since redirects are triggered individually for each element in the animated set, avoid repeatedly triggering
                callbacks by firing them only when the final element has been reached. */
             if (elementsIndex !== elementsSize - 1) {
-              complete = null;
+              begin = complete = null;
             }
 
             opts.begin = function() {

--- a/velocity.js
+++ b/velocity.js
@@ -3808,6 +3808,12 @@ return function (global, window, document, undefined) {
                 opts.display = (direction === "Down" ? (Velocity.CSS.Values.getDisplayType(element) === "inline" ? "inline-block" : "block") : "none");
             }
 
+            /* Since redirects are triggered individually for each element in the animated set, avoid repeatedly triggering
+               callbacks by firing them only when the final element has been reached. */
+            if (elementsIndex !== elementsSize - 1) {
+              complete = null;
+            }
+
             opts.begin = function() {
                 /* If the user passed in a begin callback, fire it now. */
                 begin && begin.call(elements, elements);


### PR DESCRIPTION
This is a simple fix for bug #460: using slideUp or slideDown with a begin or complete callback will cause the callback(s) to fire for each element in the animation, rather than once. The fadeIn and fadeOut animations already had a fix for this issue: call the original callbacks only on the last element in the set. I basically copy/pasted that into slideUp and slideDown, adjusting for the different variable names.
