### PR TITLE
Correctly handle "html style" property names

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -2759,7 +2759,7 @@ return function (global, window, document, undefined) {
                        colorRed, colorGreen, and colorBlue RGB component tweens into the propertiesMap (which Velocity understands) and remove the shorthand property. */
                     $.each(propertiesMap, function(property, value) {
                         /* Find shorthand color properties that have been passed a hex string. */
-                        if (RegExp("^" + CSS.Lists.colors.join("$|^") + "$").test(property)) {
+                        if (RegExp("^" + CSS.Lists.colors.join("$|^") + "$").test(CSS.Names.camelCase(property))) {
                             /* Parse the value data for each shorthand. */
                             var valueData = parsePropertyValue(value, true),
                                 endValue = valueData[0],
@@ -2784,7 +2784,7 @@ return function (global, window, document, undefined) {
                                         dataArray.push(startValueRGB[i]);
                                     }
 
-                                    propertiesMap[property + colorComponents[i]] = dataArray;
+                                    propertiesMap[CSS.Names.camelCase(property) + colorComponents[i]] = dataArray;
                                 }
 
                                 /* Remove the intermediary shorthand property entry now that we've processed it. */


### PR DESCRIPTION
When passing in a property such as "background-color", the code should
normalize with the camelCase function earlier as CSS.Lists.colors
expects the normalized version.

I am not sure where the best place to do the normalization is. This fix worked for me but I suspect a better answer would be to place the `camelCase` function as early as possible in the codepath.