### PR TITLE
Complete Pause/Resume Implementation

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -121,7 +121,7 @@
 				colorGreen: 200
 			};
 
-		for (var i = 0; i < 100; i++) {
+		for (var i = 0; i < 200; i++) {
 			var div = document.createElement("div");
 
 			div.className = "target";
@@ -983,6 +983,251 @@
 
 				start();
 			}, asyncCheckDuration);
+		});
+
+		/****************************
+		   Command: Pause / Resume
+		*****************************/
+
+		QUnit.asyncTest("Command: Pause / Resume", function() {
+			expect(10);
+
+			var $target1 = getTarget(); 
+			var $target1d = getTarget(); //delayed
+			/* Ensure an error isn't thrown when "pause" is called on a $target that isn't animating. */
+			Velocity($target1, "pause");
+			Velocity($target1d, "pause");
+
+			/* Ensure an error isn't thrown when "pause" is called on a $target that isn't animating. */
+			Velocity($target1, "resume");
+			Velocity($target1d, "resume");
+
+			/* Ensure a paused $target ceases to animate */
+			Velocity($target1, { opacity: 0 }, defaultOptions);
+			notEqual(Data($target1, pluginName).isPaused, true, "Newly active call not paused.");
+			Velocity($target1d, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { delay: 200 }));
+			notEqual(Data($target1d, pluginName).isPaused, true, "New call with delay not paused.");
+			
+			Velocity($target1, "pause");
+			Velocity($target1d, "pause");
+
+			setTimeout(function() {
+				equal(parseFloat(Velocity.CSS.getPropertyValue($target1, "opacity")), 1, "Property value unchanged after pause.");
+			}, completeCheckDuration);
+
+			setTimeout(function() {
+				equal(parseFloat(Velocity.CSS.getPropertyValue($target1d, "opacity")), 1, "Property value unchanged after pause during delay.");
+			}, 201);
+
+			/* Ensure a resumed $target proceeds to animate */
+			var $target2 = getTarget();
+			var $target2d = getTarget();
+			Velocity($target2, { opacity: 0 }, defaultOptions);
+			Velocity($target2d, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { delay: 100 }));
+			
+			Velocity($target2, "pause");
+			
+			setTimeout(function() {
+				Velocity($target2d, "pause");
+			}, 40);
+
+			Velocity($target2, "resume");
+
+			setTimeout(function() {
+				Velocity($target2d, "resume");
+			}, 80);
+
+			setTimeout(function() {
+				equal(parseFloat(Velocity.CSS.getPropertyValue($target2, "opacity")), 0, "Tween completed after pause/resume.");
+			}, completeCheckDuration);
+
+			setTimeout(function() {
+				equal(parseFloat(Velocity.CSS.getPropertyValue($target2d, "opacity")), 1, "Delayed tween did not start early after pause.");
+			}, 130);
+
+			setTimeout(function() {
+				equal(parseFloat(Velocity.CSS.getPropertyValue($target2d, "opacity")), 0, "Delayed tween completed after pause/resume.");
+			}, completeCheckDuration + 200);
+
+			/* Ensure the property values of a pause tween are midway between start and end values */
+			var $target3 = getTarget(),
+				percent = 0,
+				isPaused = false;
+
+			Velocity($target3, { opacity: 0 }, { 
+				duration: 200,
+				easing:"linear",
+				progress: function(elements, _percentComplete, _msRemaining) {
+					if(isPaused) {
+						throw new Error("Progress callback run after pause.");
+					}
+					percent = _percentComplete;
+				}
+			});
+
+			/* Pause element midway through tween */
+			setTimeout(function() {
+				Velocity($target3, "pause");
+				isPaused = true;
+			}, 100);
+
+			setTimeout(function() {
+				Velocity($target3, "resume");
+				isPaused = false;
+			}, 200);
+
+			
+			setTimeout(function() {
+				/* Property value should be linearly proportional to */
+				var val = parseFloat(Velocity.CSS.getPropertyValue($target3, "opacity"));
+
+				/* Prop value and percentage complete should correlate after pause. We need to test this since
+				the timing variables used to calculate and return the percentage complete and msRemaining are
+				modified after pause and resume comamands have been issued on the call */
+				ok(Math.round(1 - val, 4) == Math.round(percent, 4) , "Tween value and percentageComplete correlate correctly after pause.");
+
+			}, 250);
+
+
+			/* Ensure a all elements in a call are paused if any element is paused, likewise for resume */
+			var $targetA = getTarget(), $targetB = getTarget();
+			Velocity([$targetA, $targetB], { opacity: 0 }, {
+				duration:100,
+				progress:function(elements, percent, msRemaining) {
+					throw new Error("Tween does not proceed for any elements");
+				}
+			});
+			
+			Velocity($targetA, "pause");	
+
+			/* Ensure proper behavior with queue:false  */
+			var $target4 = getTarget();
+			Velocity($target4, { opacity: 0 }, { 
+				duration: 200,
+			});
+
+			var isResumed = false;
+
+			setTimeout(function() {
+				Velocity($target4, "pause");
+				Velocity($target4, { left: -20 }, { 
+					duration: 100,
+					easing:"linear",
+					queue: false,
+					begin: function(elements) {
+						ok(true, "Animation with {queue:false} will run regardless of previously paused animations.")
+					}
+				});
+
+				Velocity($target4, { top: 20 }, { 
+					duration: 100,
+					easing:"linear",
+					begin: function(elements) {
+						if(!isResumed) {
+							throw new Error("Queued animation doesn't begin until previous animation was resumed.");
+						} else {
+							ok(true, "Queued animation began after previously paused animation completed");
+						}
+					}
+				});
+			}, 100);
+
+			setTimeout(function() {
+				isResumed = true;
+				Velocity($target4, "resume");
+			}, 200);
+
+			setTimeout(function() {
+				start();
+				/* Clear out any existing test animations to prevent errors from being thrown
+				in another test */
+				try {
+					Velocity([$targetA, $target3, $target4], "stop");
+				} catch (e) {}
+			}, 800);
+
+		});
+
+		/*********************************
+		   Command: PauseAll / ResumeAll
+		**********************************/
+
+		QUnit.asyncTest("Command: Global Pause / Resume", function() {
+			expect(3);
+
+			var $target1 = getTarget(); 
+			var $target2 = getTarget();
+			var $target3 = getTarget();
+			var $target4 = getTarget();
+
+			var isPaused = false;
+			var hasProgressed2 = false;
+			Velocity($target1, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { 
+				delay: 100,
+				queue:false,
+				progress: function(elements, progress, msRemaining) {
+					if(isPaused) {
+						throw new Error("Delayed Tween should not progress when globally paused");
+					}
+				}
+			}));
+			
+			Velocity($target2, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { 
+				progress: function(elements, progress, msRemaining) {
+					if(isPaused) {
+						throw new Error("Tween should not progress when globally paused");
+					} else if(!hasProgressed2) {
+						hasProgressed2 = true;
+						ok (true, "Tween resumes on individual pause after global resume");
+					}
+				}
+			}));
+
+			Velocity.pauseAll();
+			isPaused = true;
+
+			/* Testing with custom queues */
+			var hasProgressed3 = false;
+			Velocity($target3, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { 
+				queue: "queue1",
+				progress: function(elements, progress, msRemaining) {
+					if(!hasProgressed3) {
+						hasProgressed3 = true;
+						ok (true, "Tweens created after global pause begin immediately");
+					}
+				}
+			}));
+
+			var hasProgressed4 = false;
+			Velocity($target4, { opacity: 0 }, Velocity.Utilities.extend({}, defaultOptions, { 
+				queue: "queue2",
+				progress: function(elements, progress, msRemaining) {
+					if(isPaused) {
+						throw new Error("Tween on paused queue should not progress");
+					} else if(!hasProgressed4) {
+						hasProgressed4 = true;
+						ok (true, "Paused tweens on a queue resume after a global resumeAll call");
+					}
+				}
+			}));
+
+			/* Begin queued animations */
+			Velocity.Utilities.dequeue($target4, "queue2");
+			Velocity.Utilities.dequeue($target3, "queue1");
+			
+			/* Only $target4 should pause */
+			Velocity.pauseAll("queue2");
+
+			setTimeout(function() {
+				isPaused = false;
+				Velocity.resumeAll();
+			}, 200);
+
+			setTimeout(function() {
+				start();
+				Velocity.resumeAll();
+			}, 400);
+
 		});
 
 		/******************

--- a/velocity.js
+++ b/velocity.js
@@ -635,7 +635,10 @@
 				/* Keep track of whether our RAF tick is running. */
 				isTicking: false,
 				/* Container for every in-progress call to Velocity. */
-				calls: []
+				calls: [],
+				delayedElements: {
+					count:0
+				}
 			},
 			/* Velocity's custom CSS stack. Made global for unit testing. */
 			CSS: {/* Defined below. */},
@@ -693,7 +696,62 @@
 			/* Set to 1 or 2 (most verbose) to output debug info to console. */
 			debug: false,
 			/* Use rAF high resolution timestamp when available */
-			timestamp: true
+			timestamp: true,
+			/* Pause all animations */
+			pauseAll: function(queueName) {
+				var currentTime = (new Date()).getTime();
+
+				$.each(Velocity.State.calls, function(i, activeCall) {
+											
+					if (activeCall) {
+						
+						/* If we have a queueName and this call is not on that queue, skip */
+						if (queueName !== undefined && ((activeCall[2].queue !== queueName) || (activeCall[2].queue === false))) {
+							return true;
+						}
+
+						/* Set call to paused */
+						activeCall[5] = {
+							resume:false
+						};
+					}
+				});
+
+				/* Pause timers on any currently delayed calls */
+				$.each(Velocity.State.delayedElements, function(k, element) {
+					if(!element) {
+						return;
+					}
+					pauseDelayOnElement(element, currentTime);
+				});
+			},
+			/* Resume all animations */
+			resumeAll: function(queueName) {
+				var currentTime = (new Date()).getTime();
+
+				$.each(Velocity.State.calls, function(i, activeCall) {
+						
+					if (activeCall) {
+						
+						/* If we have a queueName and this call is not on that queue, skip */
+						if (queueName !== undefined && ((activeCall[2].queue !== queueName) || (activeCall[2].queue === false))) {
+							return true;
+						}
+
+						/* Set call to resumed if it was paused */
+						if(activeCall[5]) {
+							activeCall[5].resume = true;
+						}
+					}
+				});
+				/* Resume timers on any currently delayed calls */
+				$.each(Velocity.State.delayedElements, function(k, element) {
+					if(!element) {
+						return;
+					}
+					resumeDelayOnElement(element, currentTime);
+				});
+			}
 		};
 
 		/* Retrieve the appropriate scroll anchor and property name for the browser: https://developer.mozilla.org/en-US/docs/Web/API/Window.scrollY */
@@ -715,6 +773,33 @@
 			/* jQuery <=1.4.2 returns null instead of undefined when no match is found. We normalize this behavior. */
 			return response === null ? undefined : response;
 		}
+
+		/**************
+		 Delay Timer
+		 **************/
+
+		function pauseDelayOnElement(element, currentTime) {
+			/* Check for any delay timers, and pause the set timeouts (while preserving time data)
+			to be resumed when the "resume" command is issued */
+			var data = Data(element);
+			if (data && data.delayTimer && !data.delayPaused) {
+				data.delayRemaining = data.delay - currentTime + data.delayBegin;
+				data.delayPaused = true;
+				clearTimeout(data.delayTimer.setTimeout);
+			}
+		}
+
+		function resumeDelayOnElement(element, currentTime) {
+			/* Check for any paused timers and resume */
+			var data = Data(element);
+			if (data && data.delayTimer && data.delayPaused) {
+				/* If the element was mid-delay, re initiate the timeout with the remaining delay */
+				data.delayPaused = false;
+				data.delayTimer.setTimeout = setTimeout(data.delayTimer.next, data.delayRemaining);
+			}
+		}
+
+
 
 		/**************
 		 Easing
@@ -2242,8 +2327,8 @@
 
 			/* Support is included for jQuery's argument overloading: $.animate(propertyMap [, duration] [, easing] [, complete]).
 			 Overloading is detected by checking for the absence of an object being passed into options. */
-			/* Note: The stop and finish actions do not accept animation options, and are therefore excluded from this check. */
-			if (!/^(stop|finish|finishAll)$/i.test(propertiesMap) && !$.isPlainObject(options)) {
+			/* Note: The stop/finish/pause/resume actions do not accept animation options, and are therefore excluded from this check. */
+			if (!/^(stop|finish|finishAll|pause|resume)$/i.test(propertiesMap) && !$.isPlainObject(options)) {
 				/* The utility function shifts all arguments one position to the right, so we adjust for that offset. */
 				var startingArgumentPosition = argumentIndex + 1;
 
@@ -2271,8 +2356,9 @@
 			 *********************/
 
 			/* Velocity's behavior is categorized into "actions": Elements can either be specially scrolled into view,
-			 or they can be started, stopped, or reversed. If a literal or referenced properties map is passed in as Velocity's
-			 first argument, the associated action is "start". Alternatively, "scroll", "reverse", or "stop" can be passed in instead of a properties map. */
+			 or they can be started, stopped, paused, resumed, or reversed . If a literal or referenced properties map is passed in as Velocity's
+			 first argument, the associated action is "start". Alternatively, "scroll", "reverse", "pause", "resume" or "stop" can be passed in 
+			 instead of a properties map. */
 			var action;
 
 			switch (propertiesMap) {
@@ -2283,6 +2369,125 @@
 				case "reverse":
 					action = "reverse";
 					break;
+
+				case "pause":
+					
+					/*******************
+					 Action: Pause
+					 *******************/
+
+					var currentTime = (new Date()).getTime();
+
+					/* Handle delay timers */
+					$.each(elements, function(i, element) {
+						pauseDelayOnElement(element, currentTime);
+					});
+
+					/* Pause and Resume are call-wide (not on a per element basis). Thus, calling pause or resume on a 
+					single element will cause any calls that containt tweens for that element to be paused/resumed
+					as well. */
+
+					/* Iterate through all calls and pause any that contain any of our elements */
+					$.each(Velocity.State.calls, function(i, activeCall) {
+						
+						var found = false;
+						/* Inactive calls are set to false by the logic inside completeCall(). Skip them. */
+						if (activeCall) {
+							/* Iterate through the active call's targeted elements. */
+							$.each(activeCall[1], function(k, activeElement) {
+								var queueName = (options === undefined) ? "" : options;
+
+								if (queueName !== true && (activeCall[2].queue !== queueName) && !(options === undefined && activeCall[2].queue === false)) {
+									return true;
+								}
+
+								/* Iterate through the calls targeted by the stop command. */
+								$.each(elements, function(l, element) {
+									/* Check that this call was applied to the target element. */
+									if (element === activeElement) {
+
+										/* Set call to paused */
+										activeCall[5] = {
+											resume:false
+										};
+
+										/* Once we match an element, we can bounce out to the next call entirely */
+										found = true;
+										return false;
+									}
+								});
+
+								/* Proceed to check next call if we have already matched */
+								if(found) {
+									return false;
+								}
+							});
+						}
+
+					});
+
+					/* Since pause creates no new tweens, exit out of Velocity. */
+					return getChain();
+
+				case "resume":
+
+					/*******************
+					 Action: Resume
+					 *******************/
+
+					/* Handle delay timers */
+					$.each(elements, function(i, element) {
+						resumeDelayOnElement(element, currentTime);
+					});
+					
+					/* Pause and Resume are call-wide (not on a per elemnt basis). Thus, calling pause or resume on a 
+					single element will cause any calls that containt tweens for that element to be paused/resumed
+					as well. */
+
+					/* Iterate through all calls and pause any that contain any of our elements */
+					$.each(Velocity.State.calls, function(i, activeCall) {
+						var found = false;
+						/* Inactive calls are set to false by the logic inside completeCall(). Skip them. */
+						if (activeCall) {
+							/* Iterate through the active call's targeted elements. */
+							$.each(activeCall[1], function(k, activeElement) {
+								var queueName = (options === undefined) ? "" : options;
+
+								if (queueName !== true && (activeCall[2].queue !== queueName) && !(options === undefined && activeCall[2].queue === false)) {
+									return true;
+								}
+
+								/* Skip any calls that have never been paused */
+								if(!activeCall[5]) {
+									return true;
+								}
+
+								/* Iterate through the calls targeted by the stop command. */
+								$.each(elements, function(l, element) {
+									/* Check that this call was applied to the target element. */
+									if (element === activeElement) {
+										
+										/* Flag a pause object to be resumed, which will occur during the next tick. In
+										addition, the pause object will at that time be deleted */
+										activeCall[5].resume = true;
+										
+										/* Once we match an element, we can bounce out to the next call entirely */
+										found = true;
+										return false;
+									}
+								});
+
+								/* Proceed to check next call if we have already matched */
+								if(found) {
+									return false;
+								}
+							});
+						}
+
+					});
+					
+					/* Since resume creates no new tweens, exit out of Velocity. */
+					return getChain();
 
 				case "finish":
 				case "finishAll":
@@ -2549,10 +2754,29 @@
 						Velocity.velocityQueueEntryFlag = true;
 
 						/* The ensuing queue item (which is assigned to the "next" argument that $.queue() automatically passes in) will be triggered after a setTimeout delay.
-						 The setTimeout is stored so that it can be subjected to clearTimeout() if this animation is prematurely stopped via Velocity's "stop" command. */
+						 The setTimeout is stored so that it can be subjected to clearTimeout() if this animation is prematurely stopped via Velocity's "stop" command, and
+						 delayBegin/delayTime is used to ensure we can "pause" and "resume" a tween that is still mid-delay. */
+
+						/* Temporarily store delayed elements to facilite access for global pause/resume */
+						var callIndex = Velocity.State.delayedElements.count ++;
+						Velocity.State.delayedElements[callIndex] = element;
+
+						var delayComplete = (function(index) {
+							return function() {
+								/* Clear the temporary element */
+								Velocity.State.delayedElements[index] = false;
+
+								/* Finally, issue the call */
+								next();
+							};
+						})(callIndex);
+
+
+						Data(element).delayBegin = (new Date()).getTime();
+						Data(element).delay = parseFloat(opts.delay);
 						Data(element).delayTimer = {
 							setTimeout: setTimeout(next, parseFloat(opts.delay)),
-							next: next
+							next: delayComplete
 						};
 					});
 				}
@@ -3442,7 +3666,7 @@
 						if (elementsIndex === elementsLength - 1) {
 							/* Add the current call plus its associated metadata (the element set and the call's options) onto the global call container.
 							 Anything on this call container is subjected to tick() processing. */
-							Velocity.State.calls.push([call, elements, opts, null, promiseData.resolver]);
+							Velocity.State.calls.push([call, elements, opts, null, promiseData.resolver, null, 0]);
 
 							/* If the animation tick isn't running, start it. (Velocity shuts it off when there are no active calls to process.) */
 							if (Velocity.State.isTicking === false) {
@@ -3462,7 +3686,27 @@
 					/* Since this buildQueue call doesn't respect the element's existing queue (which is where a delay option would have been appended),
 					 we manually inject the delay property here with an explicit setTimeout. */
 					if (opts.delay) {
-						setTimeout(buildQueue, opts.delay);
+
+						/* Temporarily store delayed elements to facilitate access for global pause/resume */
+						var callIndex = Velocity.State.delayedElements.count++;
+						Velocity.State.delayedElements[callIndex] = element;
+
+						var delayComplete = (function(index) {
+							return function() {
+								/* Clear the temporary element */
+								Velocity.State.delayedElements[index] = false;
+
+								/* Finally, issue the call */
+								buildQueue();
+							};
+						})(callIndex);
+
+						Data(element).delayBegin = (new Date()).getTime();
+						Data(element).delay = parseFloat(opts.delay);
+						Data(element).delayTimer = {
+							setTimeout: setTimeout(buildQueue, parseFloat(opts.delay)),
+							next: delayComplete
+						};
 					} else {
 						buildQueue();
 					}
@@ -3654,7 +3898,11 @@
 							opts = callContainer[2],
 							timeStart = callContainer[3],
 							firstTick = !!timeStart,
-							tweenDummyValue = null;
+							tweenDummyValue = null,
+							pauseObject = callContainer[5],
+							millisecondsEllapsed = callContainer[6];
+
+
 
 					/* If timeStart is undefined, then this is the first time that this call has been processed by tick().
 					 We assign timeStart now so that its value is as close to the real animation start time as possible.
@@ -3668,10 +3916,25 @@
 						timeStart = Velocity.State.calls[i][3] = timeCurrent - 16;
 					}
 
+					/* If a pause object is present, skip processing unless it has been set to resume */
+					if(pauseObject) {
+						if(pauseObject.resume === true) {
+							/* Update the time start to accomodate the paused completion amount */
+							timeStart = callContainer[3] = Math.round(timeCurrent - millisecondsEllapsed - 16);
+
+							/* Remove pause object after processing */
+							callContainer[5] = null;
+						} else {
+							continue;
+						}
+					}
+
+					millisecondsEllapsed = callContainer[6] = timeCurrent - timeStart;
+
 					/* The tween's completion percentage is relative to the tween's start time, not the tween's start value
 					 (which would result in unpredictable tween durations since JavaScript's timers are not particularly accurate).
 					 Accordingly, we ensure that percentComplete does not exceed 1. */
-					var percentComplete = Math.min((timeCurrent - timeStart) / opts.duration, 1);
+					var percentComplete = Math.min((millisecondsEllapsed) / opts.duration, 1);
 
 					/**********************
 					 Element Iteration
@@ -3683,7 +3946,7 @@
 								element = tweensContainer.element;
 
 						/* Check to see if this element has been deleted midway through the animation by checking for the
-						 continued existence of its data cache. If it's gone, skip animating this element. */
+						 continued existence of its data cache. If it's gone, or the element is currently paused, skip animating this element. */
 						if (!Data(element)) {
 							continue;
 						}


### PR DESCRIPTION
Hello!
After looking around for pause/resume info on Velocity, and finding a few issues on the matter (https://github.com/julianshapiro/velocity/issues/14, https://github.com/julianshapiro/velocity/issues/694), I've built out what I believe to be a fairly robust implementation of the "pause" and "resume" commands. It follows the same pattern of application as the "stop" command, and works on both immediate and delayed calls, and includes functional tests.

The general implementation works as follows:
On pause:
    if delayed, clear delay timeout, store remaining timing information
    else,  flag call as paused, store completion percent

On resume: 
    if delayed, setTimeout using stored timing info
    else, flag call as resumed

On tick:
   if paused, skip
   if resumed, reset call timeStart to currentTime - (duration * percentComplete) and clear paused flag

It's not a small PR, but I did attempt to build it in the spirit of how the rest of the library had been structured. If you have any questions or suggestions, let me know! If you do want to merge, I can rebase into one commit if you prefer.
