### PR TITLE
Fixed incorrect usage of nodeType

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -362,7 +362,7 @@
 			function offsetParentFn(elem) {
 				var offsetParent = elem.offsetParent || document;
 
-				while (offsetParent && (offsetParent.nodeType.toLowerCase !== "html" && offsetParent.style.position === "static")) {
+				while (offsetParent && (offsetParent.nodeName.toLowerCase !== "html" && offsetParent.style && offsetParent.style.position === "static")) {
 					offsetParent = offsetParent.offsetParent;
 				}
 


### PR DESCRIPTION
* The condition `nodeType.toLowerCase !== "html"` is always true, `nodeType` returns `9` for `documentElement`. The intended property to check must be `nodeName`.
* `offsetParent` defaults to `document`. `document` doesn't have a `style` (`documentElement` does) , so it needs a truthy check