### PR TITLE
Prevent console.log error in IE9 or less

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -2867,7 +2867,7 @@
 						if (promiseData.promise) {
 							promiseData.rejecter(new Error(abortError));
 						} else {
-							console.log(abortError);
+							window.console && console.log(abortError);
 						}
 
 						return getChain();


### PR DESCRIPTION
console.log doesn't always exist, so this throws an error