### PR TITLE
IE9 sometimes checks against window which can have length 0

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -581,6 +581,7 @@
 			/* NOTE: HTMLFormElements also have a length. */
 			isWrapped: function(variable) {
 				return variable
+						&& variable !== window
 						&& Type.isNumber(variable.length)
 						&& !Type.isString(variable)
 						&& !Type.isFunction(variable)


### PR DESCRIPTION
Fixes #746 and maybe #747 (didn't test IE8)