### PR TITLE
Fix performance.now() polyfill

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -498,8 +498,8 @@
 		var performance = (function() {
 			var perf = window.performance || {};
 
-			if (!Object.prototype.hasOwnProperty.call(perf, "now")) {
-				var nowOffset = perf.timing && perf.timing.domComplete ? perf.timing.domComplete : (new Date()).getTime();
+			if (typeof perf.now !== "function") {
+				var nowOffset = perf.timing && perf.timing.navigationStart ? perf.timing.navigationStart : (new Date()).getTime();
 
 				perf.now = function() {
 					return (new Date()).getTime() - nowOffset;


### PR DESCRIPTION
This fixes the `performance.now()` polyfill:

* In browsers that support `performance.now()`, it won't be overwritten
* In browsers that don't support `performance.now()` but do support NavigationTiming, it will use `navigationStart` as the time-origin instead of `domComplete`

For a more detailed explanation, please see https://github.com/julianshapiro/velocity/issues/762