### PR TITLE
Fix 2 issues breaking IE8 compatibility

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -543,11 +543,6 @@
 				return Array.prototype.slice;
 			} catch (e) { // Fails in IE < 9
 
-				// Quick exit if we've already defined the function.
-				// Just return it now rather than redefining it.
-				if (Array.prototype._vel_slice !== undefined)
-					return Array.prototype._vel_slice;
-
 				// This will work for genuine arrays, array-like objects, 
 				// NamedNodeMap (attributes, entities, notations),
 				// NodeList (e.g., getElementsByTagName), HTMLCollection (e.g., childNodes),

--- a/velocity.js
+++ b/velocity.js
@@ -540,7 +540,7 @@
 			try {
 				// Can't be used with DOM elements in IE < 9
 				slice.call(document.documentElement);
-				return Array.prototype.slice;
+				return slice;
 			} catch (e) { // Fails in IE < 9
 
 				// This will work for genuine arrays, array-like objects, 

--- a/velocity.js
+++ b/velocity.js
@@ -547,7 +547,7 @@
 				// NamedNodeMap (attributes, entities, notations),
 				// NodeList (e.g., getElementsByTagName), HTMLCollection (e.g., childNodes),
 				// and will not fail on other DOM objects (as do DOM elements in IE < 9)
-				Array.prototype._vel_slice = function(begin, end) {
+				return function(begin, end) {
 					// IE < 9 gets unhappy with an undefined end argument
 					end = (end !== undefined) ? end : this.length;
 
@@ -587,8 +587,6 @@
 
 					return cloned;
 				};
-
-				return Array.prototype._vel_slice;
 			}
 		})();
 

--- a/velocity.js
+++ b/velocity.js
@@ -1488,7 +1488,7 @@
 				getUnit: function(str, start) {
 					var unit = (str.substr(start || 0, 5).match(/^[a-z%]+/) || [])[0] || "";
 
-					if (unit && $.inArray(unit, CSS.Lists.units) >= 0) {
+					if (unit && CSS.Lists.units.indexOf(unit) >= 0) {
 						return unit;
 					}
 					return "";
@@ -3897,7 +3897,7 @@
 
 							/* Find shorthand color properties that have been passed a hex string. */
 							/* Would be quicker to use CSS.Lists.colors.includes() if possible */
-							if ($.inArray(propertyName, CSS.Lists.colors) >= 0) {
+							if (CSS.Lists.colors.indexOf(propertyName) >= 0) {
 								/* Parse the value data for each shorthand. */
 								var endValue = valueData[0],
 										easing = valueData[1],

--- a/velocity.js
+++ b/velocity.js
@@ -535,23 +535,30 @@
 		 * called on other DOM objects.
 		 */
 		var _slice = (function() {
-			var _fslice = Array.prototype.slice;
+			var slice = Array.prototype.slice;
 
 			try {
 				// Can't be used with DOM elements in IE < 9
-				_fslice.call(document.documentElement);
+				slice.call(document.documentElement);
+				return Array.prototype.slice;
 			} catch (e) { // Fails in IE < 9
+
+				// Quick exit if we've already defined the function.
+				// Just return it now rather than redefining it.
+				if (Array.prototype._vel_slice !== undefined)
+					return Array.prototype._vel_slice;
+
 				// This will work for genuine arrays, array-like objects, 
 				// NamedNodeMap (attributes, entities, notations),
 				// NodeList (e.g., getElementsByTagName), HTMLCollection (e.g., childNodes),
 				// and will not fail on other DOM objects (as do DOM elements in IE < 9)
-				Array.prototype.slice = function(begin, end) {
+				Array.prototype._vel_slice = function(begin, end) {
 					// IE < 9 gets unhappy with an undefined end argument
-					end = (typeof end !== 'undefined') ? end : this.length;
+					end = (end !== undefined) ? end : this.length;
 
 					// For native Array objects, we use the native slice function
-					if (Object.prototype.toString.call(this) === '[object Array]'){
-						return _fslice.call(this, begin, end); 
+					if (this.slice){
+						return slice.call(this, begin, end); 
 					}
 
 					// For array like object we handle it ourselves.
@@ -585,9 +592,9 @@
 
 					return cloned;
 				};
-			}
 
-			return Array.prototype.slice;
+				return Array.prototype._vel_slice;
+			}
 		})();
 
 		function sanitizeElements(elements) {


### PR DESCRIPTION
Fix the shim _slice to work in IE8. Also caches the "slice" shim the first time it's used.

Fix "indexof" to use the jquery ".inArray" to keep IE8 compatibility.