### PR TITLE
Correct the initialization of the variable "firstTick"

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -4217,7 +4217,7 @@
 							call = callContainer[0],
 							opts = callContainer[2],
 							timeStart = callContainer[3],
-							firstTick = !!timeStart,
+							firstTick = !timeStart,
 							tweenDummyValue = null,
 							pauseObject = callContainer[5],
 							millisecondsEllapsed = callContainer[6];


### PR DESCRIPTION
In the "tick" handler code, there's a flag called `firstTick` that is used to avoid updating a property value that's already correct for the current tween. However, `firstTick` is initialized based on the state of the `timeStart` value, which is unset on the first tick; the initialization incorrectly inverts that test, using `!!timeStart` instead of `!timeStart`.

The upshot of this is that the test to avoid updating a property an *all but* the first tick actually *only* avoids updating the property on the first tick; for most of the animation that optimization is ignored. Worse, that can cause issues for force-fed property values that might need initialization on that first tick (see issue 543).
