### PR TITLE
Fix crash on queue stop

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -3004,7 +3004,12 @@
 				/* Note: Velocity rolls its own delay function since jQuery doesn't have a utility alias for $.fn.delay()
 				 (and thus requires jQuery element creation, which we avoid since its overhead includes DOM querying). */
 				if (parseFloat(opts.delay) && opts.queue !== false) {
-					$.queue(element, opts.queue, function(next) {
+					$.queue(element, opts.queue, function(next, clearQueue) {
+						if (clearQueue === true) {
+							/* Do not continue with animation queueing. */
+							return true;
+						}
+
 						/* This is a flag used to indicate to the upcoming completeCall() function that this queue entry was initiated by Velocity. See completeCall() for further details. */
 						Velocity.velocityQueueEntryFlag = true;
 


### PR DESCRIPTION
There is a crash when stopping a delayed animation in a named queue:
https://jsfiddle.net/apw8wy1p/5/

I see that the second parameter in the queue is correctly handled in  [Line 4036](https://github.com/julianshapiro/velocity/blob/39ef88aa95ef361e09bf309429d3d514eb898e2b/velocity.js#L4036) but seems to be missing in [Line 3007](https://github.com/julianshapiro/velocity/blob/39ef88aa95ef361e09bf309429d3d514eb898e2b/velocity.js#L3007). This PR adds a simple handling of clearQueue at this place, and seems to work for me.

I'd appreciate a bugfix release, since we'd need a npm release to use this fix.

