### PR TITLE
Bugfix: Stopping custom named queue breaks default main queue activeTweens

### DIFF
--- a/velocity.js
+++ b/velocity.js
@@ -2835,10 +2835,10 @@
 										if (propertiesMap === "stop") {
 											/* Since "reverse" uses cached start values (the previous call's endValues), these values must be
 											 changed to reflect the final value that the elements were actually tweened to. */
-											/* Note: If only queue:false animations are currently running on an element, it won't have a tweensContainer
-											 object. Also, queue:false animations can't be reversed. */
+											/* Note: If only queue:false/queue:"custom" animations are currently running on an element, it won't have a tweensContainer
+											 object. Also, queue:false/queue:"custom" animations can't be reversed. */
 											var data = Data(element);
-											if (data && data.tweensContainer && queueName !== false) {
+											if (data && data.tweensContainer && (queueName === true || queueName === "")) {
 												$.each(data.tweensContainer, function(m, activeTween) {
 													activeTween.endValue = activeTween.currentValue;
 												});


### PR DESCRIPTION
see https://github.com/julianshapiro/velocity/issues/889

#### Checklist

* Have you linked to relevant open issues?: Yes
* I agree for this to be covered by the Velocity [license](https://github.com/julianshapiro/velocity/blob/master/LICENSE.md)?: Yes

#### Please describe this Pull Request in as much detail as possible:
Old behaviour: stop calls with custom queue changed activeTween.endValue of default queue to activeTween.currentValue.
New behaviour: stop calls with custom queue don't touch default queue activeTween