### PR TITLE
Minimal fix for #885: Animations don't work in IE11

### DIFF
--- a/src/utility.ts
+++ b/src/utility.ts
@@ -50,7 +50,7 @@ export function defineProperty(proto: any, name: string, value: any, readonly?: 
  * first value that is valid.
  */
 export function getValue<T>(...args: T[]): T {
-	for (const arg of arguments) {
+	for (const arg of args) {
 		if (arg !== undefined && arg === arg) {
 			return arg;
 		}


### PR DESCRIPTION
#### Checklist

* Have you linked to relevant open issues?:
https://github.com/julianshapiro/velocity/issues/885
* I agree for this to be covered by the Velocity [license](https://github.com/julianshapiro/velocity/blob/master/LICENSE.md)?:
Yes, I agree

#### Please describe this Pull Request in as much detail as possible:
As stated in #885, there is a problem running animations in IE11. I traced it to the utility function `getValue`, which tries to iterate `arguments`. This works in browsers with proper iterator support, but falls apart otherwise. The problem lies in `arguments` being of type `object` and not `array` so we can't really polyfill it (see https://github.com/babel/babel/issues/1181).

With this PR, the `args` variable is iterated instead, since it is a proper array and can be polyfilled. The `args`-array is created and filled anyway https://github.com/julianshapiro/velocity/blob/e238e873b5d22bf41f5f1823e9bb43022f3eb08e/velocity.es5.js#L150-L152 so this should be of minimal impact.

#### People who contributed to this change:
Michael Wagner